### PR TITLE
ZEPPELIN-88: Group label truncated when containing periods

### DIFF
--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -1381,7 +1381,7 @@ angular.module('zeppelinWebApp')
       if (groups.length === 1 && values.length === 1) {
         for (d3gIndex = 0; d3gIndex < d3g.length; d3gIndex++) {
           var colName = d3g[d3gIndex].key;
-          colName = colName.split('.')[0];
+          colName = colName.substring(0, colName.lastIndexOf("."));
           d3g[d3gIndex].key = colName;
         }
       }

--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -817,9 +817,7 @@ angular.module('zeppelinWebApp')
 
     var d3g = [];
 
-    // FIXME: pivot(data) will alter the rows order
-    console.log('data is\n %s \n', JSON.stringify(data));
-    // ------
+    // console.log('data is\n %s \n', JSON.stringify(data));
 
     if (type === 'scatterChart') {
       var scatterData = setScatterChart(data, refresh);
@@ -861,10 +859,7 @@ angular.module('zeppelinWebApp')
                         .scatter.useVoronoi(false);
     } else {
       var p = pivot(data);
-
-      // FIXME: pivot(data) will alter the rows order
-      console.log('Pivot(data) is\n %s \n', JSON.stringify(p));
-      // ------
+      // console.log('Pivot(data) is\n %s \n', JSON.stringify(p));
 
       if (type === 'pieChart') {
         var d = pivotDataToD3ChartFormat(p, true).d3g;
@@ -900,9 +895,7 @@ angular.module('zeppelinWebApp')
         $scope.chart[type].forceY([0]); // force y-axis minimum to 0 for line chart.
       }
 
-      // FIXME: pivotDataToD3ChartFormat(p)
-      console.log('D3CharFormat is %s', JSON.stringify(d3g));
-      // ------
+      // console.log('pivotDataD3ChartFormat is %s', JSON.stringify(d3g));
 
     }
 

--- a/zeppelin-web/app/scripts/controllers/paragraph.js
+++ b/zeppelin-web/app/scripts/controllers/paragraph.js
@@ -1313,8 +1313,10 @@ angular.module('zeppelinWebApp')
     var colIdx = 0;
     var rowIndexValue = {};
 
-    for (var k in rows) {
-      traverse(sKey, schema[sKey], k, rows[k], function(rowName, rowValue, colName, value) {
+    for (var kk in rows) {
+      var row = rows[kk];
+      var k = Object.keys(row)[0];
+      traverse(sKey, schema[sKey], k, row[k], function(rowName, rowValue, colName, value) {
         //console.log("RowName=%o, row=%o, col=%o, value=%o", rowName, rowValue, colName, value);
         if (rowNameIndex[rowValue] === undefined) {
           rowIndexValue[rowIdx] = rowValue;


### PR DESCRIPTION
Get colname until last index of "." instead of getting the first part of splitting on "." to maintain the full name of the group column.
