### PR TITLE
Support for Spark version 1.5.1

### DIFF
--- a/spark-dependencies/pom.xml
+++ b/spark-dependencies/pom.xml
@@ -458,7 +458,7 @@
     <profile>
       <id>spark-1.5</id>
       <properties>
-        <spark.version>1.5.0</spark.version>
+        <spark.version>1.5.1</spark.version>
         <akka.group>com.typesafe.akka</akka.group>
         <akka.version>2.3.11</akka.version>
         <protobuf.version>2.5.0</protobuf.version>

--- a/spark/src/main/java/org/apache/zeppelin/spark/SparkVersion.java
+++ b/spark/src/main/java/org/apache/zeppelin/spark/SparkVersion.java
@@ -31,7 +31,8 @@ public enum SparkVersion {
   SPARK_1_3_1,
   SPARK_1_4_0,
   SPARK_1_4_1,
-  SPARK_1_5_0;
+  SPARK_1_5_0,
+  SPARK_1_5_1;
 
   private int version;
 

--- a/spark/src/test/java/org/apache/zeppelin/spark/SparkVersionTest.java
+++ b/spark/src/test/java/org/apache/zeppelin/spark/SparkVersionTest.java
@@ -26,7 +26,7 @@ public class SparkVersionTest {
   public void testSparkVersion() {
     // test equals
     assertTrue(SparkVersion.SPARK_1_2_0 == SparkVersion.fromVersionString("1.2.0"));
-    assertTrue(SparkVersion.SPARK_1_5_0 == SparkVersion.fromVersionString("1.5.0-SNAPSHOT"));
+    assertTrue(SparkVersion.SPARK_1_5_0 == SparkVersion.fromVersionString("1.5.0"));
 
     // test newer than
     assertFalse(SparkVersion.SPARK_1_2_0.newerThan(SparkVersion.SPARK_1_2_0));

--- a/zeppelin-interpreter/src/test/java/org/apache/zeppelin/display/RegexForFQNTest.java
+++ b/zeppelin-interpreter/src/test/java/org/apache/zeppelin/display/RegexForFQNTest.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.zeppelin.display;
 
 import java.util.regex.Matcher;


### PR DESCRIPTION
Provides support for Spark 1.5.1. When packaging, some tests from zeppelin-server won't pass due to runtime scheduler (ZeppelinSparkClusterTest) but they do pass when ran in isolation.
